### PR TITLE
Potential fix for code scanning alert no. 4: Shell command built from environment values

### DIFF
--- a/sui/testing/scripts/upgrade-token-bridge.ts
+++ b/sui/testing/scripts/upgrade-token-bridge.ts
@@ -9,7 +9,7 @@ import {
   Ed25519Keypair,
   testnetConnection,
 } from "@mysten/sui.js";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { resolve } from "path";
 import * as fs from "fs";
 
@@ -107,9 +107,10 @@ function buildForBytecodeAndDigest(packagePath: string) {
     dependencies: string[];
     digest: number[];
   } = JSON.parse(
-    execSync(
-      `sui move build --dump-bytecode-as-base64 -p ${packagePath} 2> /dev/null`,
-      { encoding: "utf-8" }
+    execFileSync(
+      "sui",
+      ["move", "build", "--dump-bytecode-as-base64", "-p", packagePath],
+      { encoding: "utf-8", stdio: "pipe" }
     )
   );
   return {


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/wormhole/security/code-scanning/4](https://github.com/codeallthethingsbreak/wormhole/security/code-scanning/4)

To address the issue, the shell command should be refactored to avoid direct interpolation of the `packagePath` variable into the command string. Instead, the `execFileSync` function should be used, which allows passing arguments separately to the command, ensuring that special characters in the path are properly escaped and do not alter the shell command's behavior.

**Steps to fix:**
1. Replace `execSync` with `execFileSync`.
2. Pass the command (`sui`) and its arguments (`move build --dump-bytecode-as-base64 -p <packagePath>`) as separate parameters to `execFileSync`.
3. Ensure the `packagePath` is passed as an argument rather than interpolated into the command string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
