### PR TITLE
Potential fix for code scanning alert no. 3: Shell command built from environment values

### DIFF
--- a/sui/testing/scripts/upgrade-wormhole.ts
+++ b/sui/testing/scripts/upgrade-wormhole.ts
@@ -9,7 +9,7 @@ import {
   Ed25519Keypair,
   testnetConnection,
 } from "@mysten/sui.js";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { resolve } from "path";
 import * as fs from "fs";
 
@@ -102,9 +102,10 @@ function buildForBytecodeAndDigest(packagePath: string) {
     dependencies: string[];
     digest: number[];
   } = JSON.parse(
-    execSync(
-      `sui move build --dump-bytecode-as-base64 -p ${packagePath} 2> /dev/null`,
-      { encoding: "utf-8" }
+    execFileSync(
+      "sui",
+      ["move", "build", "--dump-bytecode-as-base64", "-p", packagePath],
+      { encoding: "utf-8", stdio: "pipe" }
     )
   );
   return {


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/wormhole/security/code-scanning/3](https://github.com/codeallthethingsbreak/wormhole/security/code-scanning/3)

To fix the issue, we should avoid dynamically constructing the shell command as a single string. Instead, we can use `execFileSync` from the `child_process` module, which allows us to pass the command and its arguments separately. This approach avoids interpretation of special characters by the shell, mitigating the risk of shell injection.

Specifically:
1. Replace the dynamically constructed shell command with a call to `execFileSync`.
2. Pass the `sui move build` command as the first argument and its options (e.g., `--dump-bytecode-as-base64`, `-p`, and the `packagePath`) as an array of arguments.
3. Ensure the behavior of the command remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
