### PR TITLE
Potential fix for code scanning alert no. 2: Shell command built from environment values

### DIFF
--- a/clients/js/src/chains/sui/publish.ts
+++ b/clients/js/src/chains/sui/publish.ts
@@ -5,7 +5,7 @@ import {
   RawSigner,
   TransactionBlock,
 } from "@mysten/sui.js";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import fs from "fs";
 import { resolve } from "path";
 import { MoveToml } from "./MoveToml";
@@ -19,8 +19,9 @@ export const buildPackage = (packagePath: string): SuiBuildOutput => {
   }
 
   return JSON.parse(
-    execSync(
-      `sui move build --dump-bytecode-as-base64 --path ${packagePath} 2> /dev/null`,
+    execFileSync(
+      "sui",
+      ["move", "build", "--dump-bytecode-as-base64", "--path", packagePath],
       {
         encoding: "utf-8",
       }


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/wormhole/security/code-scanning/2](https://github.com/codeallthethingsbreak/wormhole/security/code-scanning/2)

To fix the issue, the shell command should be constructed using `execFileSync` instead of `execSync`. This allows the command and its arguments to be passed separately, avoiding shell interpretation of special characters in `packagePath`. Specifically:
1. Replace the dynamic shell command construction with a safer approach using `execFileSync`.
2. Pass the `packagePath` as an argument to the `sui move build` command, ensuring it is treated as a literal string.
3. Update the `buildPackage` function in `clients/js/src/chains/sui/publish.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
