### PR TITLE
Potential fix for code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/algorand/audit_test/src/sdk/Deployer.ts
+++ b/algorand/audit_test/src/sdk/Deployer.ts
@@ -667,9 +667,8 @@ export class Deployer {
             const pythonCommand = 'python3.10'
             const preArgs = overrideArgs ?? []
             const args = [...preArgs, ...outputPaths]
-            const cmd = `${pythonCommand} "${pytealSourceFile}" ${args.join(' ')}`
-             console.log(`Running command ${cmd}`)
-            const logs = await util.promisify(child_process.exec)(cmd)
+            console.log(`Running command ${pythonCommand} with arguments:`, [pytealSourceFile, ...args])
+            const logs = await util.promisify(child_process.execFile)(pythonCommand, [pytealSourceFile, ...args])
             if (logs.stderr && logs.stderr.length > 0) {
                 throw Error(`Could not compile file: ${pytealSourceFile} with ${pythonCommand}.\nError: ${logs.stderr}`)
             }


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/wormhole/security/code-scanning/1](https://github.com/codeallthethingsbreak/wormhole/security/code-scanning/1)

To fix the issue, we will replace the use of `child_process.exec` with `child_process.execFile`. This approach separates the command and its arguments, preventing the shell from interpreting the input. Specifically:
1. The `cmd` string will be split into a command (`pythonCommand`) and an array of arguments (`args`).
2. The `child_process.execFile` function will be used to execute the command with the arguments array.
3. This change ensures that special characters in the arguments are treated as literal values and not interpreted by the shell.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
